### PR TITLE
fpm: update to v0.11.0

### DIFF
--- a/mingw-w64-fpm/PKGBUILD
+++ b/mingw-w64-fpm/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=fpm
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.10.0
+pkgver=0.11.0
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
@@ -18,8 +18,8 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
 optdepends=("git: Support for fetching projects with git")
 source=(${_realname}-${pkgver}.zip::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.zip"
         ${_realname}-${pkgver}.F90::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.F90")
-sha256sums=('00d687e17bdada4dcae0ff1ea2e01bad287dcc77a74c3bbde0c9ff9633b655bb'
-            '48e563db74af6b9396ebe4a67bd371210e2ea8c6e2b3cc230e68183ce7509422')
+sha256sums=('f6c998c9afd39eb42c7e80a306cfbed5faa77eaa42eb4f75b93864c338db1795'
+            '988a3317ee2448ee7207d0a29410f08a79c86bddac3314b2a175801a9cf58d27')
 noextract=(${_realname}-${pkgver}.F90)
 
 build() {

--- a/mingw-w64-fpm/PKGBUILD
+++ b/mingw-w64-fpm/PKGBUILD
@@ -5,6 +5,7 @@ pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
 pkgver=0.11.0
 pkgrel=1
+bootstrap=0.8.2
 arch=('any')
 mingw_arch=('mingw64' 'ucrt64')
 pkgdesc="Fortran package manager (mingw-w64)"
@@ -16,11 +17,12 @@ depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs"
 makedepends=("${MINGW_PACKAGE_PREFIX}-fc"
              "git")
 optdepends=("git: Support for fetching projects with git")
+_bootstrap_src=${_realname}-${bootstrap}.F90
 source=(${_realname}-${pkgver}.zip::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.zip"
-        ${_realname}-${pkgver}.F90::"${url}/releases/download/v${pkgver}/fpm-${pkgver}.F90")
+        ${_bootstrap_src}::"${url}/releases/download/v${bootstrap}/fpm-${bootstrap}.F90")
 sha256sums=('f6c998c9afd39eb42c7e80a306cfbed5faa77eaa42eb4f75b93864c338db1795'
-            '988a3317ee2448ee7207d0a29410f08a79c86bddac3314b2a175801a9cf58d27')
-noextract=(${_realname}-${pkgver}.F90)
+            '0c95309f365a40900108f3325e17e99a0456ce76046c37326349bf61b3df447a')
+noextract=(${_bootstrap_src})
 
 build() {
   cd "${srcdir}/${_realname}-${pkgver}"
@@ -34,7 +36,8 @@ build() {
   fi
 
   mkdir -p "${_build}/bootstrap"
-  "${_fc}" -J "${_build}/bootstrap" -o "${_build}/bootstrap/fpm" "${srcdir}"/${_realname}-${pkgver}.F90
+  "${_fc}" -J "${_build}/bootstrap" -o "${_build}/bootstrap/fpm" "${srcdir}/${_bootstrap_src}"
+  
 
   "${_build}/bootstrap/fpm" install \
     --compiler "${_fc}" \


### PR DESCRIPTION
The single-source fpm bootstrap file seems broken on Windows due to recent additions of C code.
For now, bootstrap the fpm build using version 0.8.2 (tested working in my Windows environment). 

Successful CI action at: https://github.com/perazz/MINGW-packages/actions/runs/13774668208

PS: note the second file's sha256 now refers to the 0.8.2 single-source version and should not be changed until the version used for bootstrapping is changed as well.

